### PR TITLE
feat: SYGN-13265 remove constraint on txid format

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -1572,7 +1572,6 @@
             "x-stoplight": {
               "id": "x8criwur71vzq"
             },
-            "pattern": "^[0123456789A-Za-z]+$",
             "minLength": 1
           }
         },
@@ -1861,8 +1860,7 @@
           },
           "txid": {
             "type": "string",
-            "minLength": 1,
-            "pattern": "^[0123456789A-Za-z]+$"
+            "minLength": 1
           },
           "signature": {
             "$ref": "#/components/schemas/bridgeSignature"


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary**

This pull request removes the validation pattern for the "txid" field and keeps only the minimum length constraint. The "pattern" validation for the "pattern" field was previously removed.

**Key Points**

* Validation pattern for "txid" field removed
* Minimum length constraint for "txid" field remains
* "Pattern" validation for "pattern" field previously removed. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>