### PR TITLE
feat: SYGN-13265 not allow &<> in TxID

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -1572,6 +1572,7 @@
             "x-stoplight": {
               "id": "x8criwur71vzq"
             },
+            "pattern": "^[0123456789A-Za-z]+$",
             "minLength": 1
           }
         },
@@ -1860,7 +1861,8 @@
           },
           "txid": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "^[0123456789A-Za-z]+$"
           },
           "signature": {
             "$ref": "#/components/schemas/bridgeSignature"

--- a/bridge-api.json
+++ b/bridge-api.json
@@ -1572,7 +1572,7 @@
             "x-stoplight": {
               "id": "x8criwur71vzq"
             },
-            "pattern": "^[0123456789A-Za-z]+$",
+            "pattern": "^[^&<>]+$",
             "minLength": 1
           }
         },
@@ -1862,7 +1862,7 @@
           "txid": {
             "type": "string",
             "minLength": 1,
-            "pattern": "^[0123456789A-Za-z]+$"
+            "pattern": "^[^&<>]+$"
           },
           "signature": {
             "$ref": "#/components/schemas/bridgeSignature"


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary**

This pull request introduces a new validation pattern for "x-stoplight" and "txid" fields in "bridge-api.json". The pattern uses a regex to disallow "&", "<", ">" characters, and keeps "minLength" for "txid" at 1.

**Key Points**

* New validation pattern for "x-stoplight" and "txid" fields
* Uses regex to disallow "&", "<", ">" characters
* "minLength" for "txid" remains at 1. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>