### PR TITLE
release: 1.35.0

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -202,8 +202,8 @@
               "example": {
                 "vasp_code": "VASPUSNY1",
                 "status": "maintaining",
-                "started_at": 1625097600,
-                "ended_at": 1625184000,
+                "started_at": 1724807400000,
+                "ended_at": 1724808400000,
                 "signature": "d58e5b71b8d5c9a7e1e0c89936f9f610b24219a4a8be4d3c42ec4f64747fc01f"
               }
             }

--- a/bridge-api.json
+++ b/bridge-api.json
@@ -179,6 +179,58 @@
         }
       }
     },
+    "/bridge/vasp/server-status": {
+      "post": {
+        "description": "This API is used to declare that the VASP’s server is currently in maintenance.",
+        "summary": "Bridge/VASP/ServerStatus",
+        "tags": [
+          "Bridge"
+        ],
+        "operationId": "Bridge/ServerStatus",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "deprecated": false,
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/bridgeServerStatus"
+              },
+              "example": {
+                "vasp_code": "VASPUSNY1",
+                "status": "maintaining",
+                "started_at": 1625097600,
+                "ended_at": 1625184000,
+                "signature": "d58e5b71b8d5c9a7e1e0c89936f9f610b24219a4a8be4d3c42ec4f64747fc01f"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bridgeApiResponse"
+                },
+                "examples": {
+                  "response": {
+                    "value": {
+                      "status": "OK"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/bridge/transaction/currencies": {
       "get": {
         "summary": "Bridge/Currencies",
@@ -1154,13 +1206,8 @@
             "type": "string",
             "minLength": 1
           },
-          "vasp_server_status": {
-            "type": "string",
-            "enum": [
-              "healthy",
-              "unhealthy",
-              "unknown"
-            ]
+          "vasp_server_status":{
+            "$ref": "#/components/schemas/vaspServerStatus"
           },
           "last_server_checked_at": {
             "$ref": "#/components/schemas/bridgeDate"
@@ -1213,13 +1260,8 @@
             "type": "string",
             "minLength": 1
           },
-          "vasp_server_status": {
-            "type": "string",
-            "enum": [
-              "healthy",
-              "unhealthy",
-              "unknown"
-            ]
+          "vasp_server_status":{
+            "$ref": "#/components/schemas/vaspServerStatus"
           },
           "last_server_checked_at": {
             "$ref": "#/components/schemas/bridgeDate"
@@ -1243,6 +1285,17 @@
           },
           "national_identifier": {
             "type": "string"
+          },
+          "maintenance_date_range": {
+            "type": "object",
+            "properties": {
+              "started_at": {
+                "type": "string"
+              },
+              "ended_at": {
+                "type": "string"
+              }
+            }
           }
         },
         "required": [
@@ -1954,6 +2007,39 @@
             "minItems": 1
           }
         }
+      },
+      "bridgeServerStatus": {
+        "title": "ServerStatus",
+        "description": "Server Status",
+        "type": "object",
+        "properties": {
+          "vasp_code": {
+            "$ref": "#/components/schemas/bridgeVaspCode"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["maintaining"]
+          },
+          "started_at": {
+            "type": "number"
+          },
+          "ended_at": {
+            "type": "number"
+          },
+          "signature": {
+            "$ref": "#/components/schemas/bridgeSignature"
+          }
+        },
+        "required": ["vasp_code", "status", "signature"]
+      },
+      "vaspServerStatus": {
+        "type": "string",
+        "enum": [
+          "healthy",
+          "unhealthy",
+          "unknown",
+          "maintaining"
+        ]
       }
     }
   }

--- a/bridge-api.json
+++ b/bridge-api.json
@@ -1214,6 +1214,17 @@
           },
           "vasp_sygna_registration_type": {
             "type": "string"
+          },
+          "maintenance_date_range": {
+            "type": "object",
+            "properties": {
+              "started_at": {
+                "type": "number"
+              },
+              "ended_at": {
+                "type": "number"
+              }
+            }
           }
         },
         "required": [

--- a/bridge-api.json
+++ b/bridge-api.json
@@ -1572,7 +1572,6 @@
             "x-stoplight": {
               "id": "x8criwur71vzq"
             },
-            "pattern": "^[0123456789A-Za-z]+$",
             "minLength": 1
           }
         },
@@ -1861,8 +1860,7 @@
           },
           "txid": {
             "type": "string",
-            "minLength": 1,
-            "pattern": "^[0123456789A-Za-z]+$"
+            "minLength": 1
           },
           "signature": {
             "$ref": "#/components/schemas/bridgeSignature"

--- a/bridge-api.json
+++ b/bridge-api.json
@@ -1572,6 +1572,7 @@
             "x-stoplight": {
               "id": "x8criwur71vzq"
             },
+            "pattern": "^[0123456789A-Za-z]+$",
             "minLength": 1
           }
         },
@@ -1860,7 +1861,8 @@
           },
           "txid": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "^[0123456789A-Za-z]+$"
           },
           "signature": {
             "$ref": "#/components/schemas/bridgeSignature"

--- a/bridge-api.json
+++ b/bridge-api.json
@@ -1572,7 +1572,7 @@
             "x-stoplight": {
               "id": "x8criwur71vzq"
             },
-            "pattern": "^[0123456789A-Za-z]+$",
+            "pattern": "^[^&<>]+$",
             "minLength": 1
           }
         },
@@ -1862,7 +1862,7 @@
           "txid": {
             "type": "string",
             "minLength": 1,
-            "pattern": "^[0123456789A-Za-z]+$"
+            "pattern": "^[^&<>]+$"
           },
           "signature": {
             "$ref": "#/components/schemas/bridgeSignature"


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary**

This pull request adds a new API endpoint for declaring VASP server maintenance status and updates related schema definitions.

**Key Points**

* Adds "/bridge/vasp/server-status" POST endpoint
* Introduces "bridgeServerStatus" and "vaspServerStatus" schemas
* Updates "/bridge/transaction/currencies" GET request schema
* Includes new properties in existing schema: "national\_identifier" and "maintenance\_date\_range" 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>