### PR TITLE
feat: SYGN-13849 as an originator, I can send cdd before/after cdd-request

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -1018,6 +1018,56 @@
         }
       }
     },
+    "/bridge/transaction/cdd": {
+      "post": {
+        "description": "This API is used to send the Customer Due Diligence (CDD) information either before or after it is requested by the beneficiary VASP.",
+        "summary": "Bridge/CDD",
+        "tags": [
+          "Bridge"
+        ],
+        "operationId": "Bridge/CDD",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "deprecated": false,
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/bridgeCDD"
+              },
+              "example": {
+                "transfer_id": "ad468f326ebcc2242c32aa6bf7084c44135a068d939e52c08b6d2e86eb9ef725",
+                "other_cdd_info": "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                "signature": "6e8e259319f22df4dcb1a03cf701baf2d7fbd668fe3250f60ed12bb5c462fb712e9b68069ec0893042188a81a384da1fec5eb06173fadd327318db8430e606eb"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bridgeApiResponse"
+                },
+                "examples": {
+                  "response": {
+                    "value": {
+                      "status": "OK"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/bridge/wallet-address-filter": {
       "post": {
         "description": "The Sygna Wallet Address Filter (WAF) API is a key feature that enables you to determine whether a specific wallet address belongs to a VASP or an unhosted wallet based on the Sygna server's directory and your selected blockchain analytics (KYT) vendor. If the wallet address is associated with an un-hosted wallet, your KYT vendor will return a risk score for the address. If you have not yet collaborated with a blockchain analytics vendor, please contact services@sygna.io",
@@ -2208,6 +2258,26 @@
         "required": [
           "transfer_id",
           "txid",
+          "signature"
+        ]
+      },
+      "bridgeCDD": {
+        "title": "CDD",
+        "type": "object",
+        "properties": {
+          "transfer_id": {
+            "$ref": "#/components/schemas/bridgeTransferID"
+          },
+          "other_cdd_info": {
+            "type": "string"
+          },
+          "signature": {
+            "$ref": "#/components/schemas/bridgeSignature"
+          }
+        },
+        "required": [
+          "transfer_id",
+          "other_cdd_info",
           "signature"
         ]
       },


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary**
This pull request introduces a new API endpoint "/bridge/transaction/cdd" for sending CDD information and a new request object "AddressValidationReq" for verifying beneficiary addresses.

**Key Points**

1. New API endpoint "/bridge/transaction/cdd" added for CDD information.
2. Request body defined in "bridgeCDD" schema, response follows "bridgeApiResponse" schema.
3. Endpoint secured with API key, not deprecated.
4. New request object "AddressValidationReq" for beneficiary address verification. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>