### PR TITLE
feat: SYGN-13837 callback_type is required

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -2581,6 +2581,7 @@
       },
       "bridgeCDDCallbackType": {
         "title": "CDDCallbackType",
+        "description": "'POST_CDD' is used when the originating VASP sends the permission request along with the Customer Due Diligence (CDD) information before the beneficiary VASP requests it; 'REQUEST_CDD' is used when the beneficiary VASP requests the CDD information from the originating VASP; 'RESPOND_CDD' is used when the originating VASP sends the CDD information after the beneficiary VASP requests it.",
         "type": "string",
         "enum": ["REQUEST_CDD", "POST_CDD","RESPOND_CDD"]
       }

--- a/bridge-api.json
+++ b/bridge-api.json
@@ -2065,12 +2065,17 @@
           "request_cdd_data": {
             "$ref": "#/components/schemas/bridgeRequestCddData"
           },
+          "callback_type": {
+            "$ref": "#/components/schemas/bridgeCDDCallbackType"
+          },
           "signature": {
             "$ref": "#/components/schemas/bridgeSignature"
           }
         },
         "required": [
           "transfer_id",
+          "request_cdd_data",
+          "callback_type",
           "signature"
         ],
         "additionalProperties": false
@@ -2273,11 +2278,15 @@
           },
           "signature": {
             "$ref": "#/components/schemas/bridgeSignature"
+          },
+          "callback_type": {
+            "$ref": "#/components/schemas/bridgeCDDCallbackType"
           }
         },
         "required": [
           "transfer_id",
           "other_cdd_info",
+          "callback_type",
           "signature"
         ]
       },
@@ -2569,6 +2578,11 @@
             }
           }
         }
+      },
+      "bridgeCDDCallbackType": {
+        "title": "CDDCallbackType",
+        "type": "string",
+        "enum": ["REQUEST_CDD", "POST_CDD","RESPOND_CDD"]
       }
     }
   }


### PR DESCRIPTION
callback_type 需包含在 payload 裡，不然驗簽不會過
 
 **PR Summary by Typo**
------------

 **Summary:**
Introduced new "callback\_type" property in "bridge-api.json" schema files with limited allowed values.

**Key Points:**
1. Added new property "callback\_type" to JSON schema files.
2. Property is of type string with allowed values ["REQUEST\_CDD", "POST\_CDD", "RESPOND\_CDD"].
3. Applied change to multiple schema definitions. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>