### PR TITLE
fix: type of addrs in bridgeAddressValidation

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -2343,7 +2343,11 @@
             "type": "string"
           },
           "addrs": {
-            "$ref": "#/components/schemas/bridgeAddress"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/bridgeAddress"
+            },
+            "minItems": 1
           },
           "signature": {
             "$ref": "#/components/schemas/bridgeSignature"

--- a/bridge-api.json
+++ b/bridge-api.json
@@ -2074,35 +2074,32 @@
       },
       "bridgeAddress": {
         "title": "addrs",
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "address": {
-              "type": "string",
-              "minLength": 1
-            },
-            "addr_extra_info": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "additionalProperties": {
-                  "oneOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ]
-                }
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string",
+            "minLength": 1
+          },
+          "addr_extra_info": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
               }
             }
-          },
-          "required": [
-            "address"
-          ]
-        }
+          }
+        },
+        "required": [
+          "address"
+        ]
       },
       "bridgeOriginatorVasp": {
         "title": "originator_vasp",


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary**
This pull request refactors the "bridgeAddress" format in "bridge-api.json" and updates the "addrs" field schema.

**Key Points**
1. Changes "bridgeAddress" from array to object in "bridge-api.json".
2. Adds required "address" field and optional "addr\_extra\_info" array to the object.
3. Updates "addrs" field schema in "BridgeOriginatorVasp" to be an array of bridgeAddress objects. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>