### PR TITLE
feat: SYGN-13877 add canceled to the permission status enum

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -2056,6 +2056,7 @@
             "enum": [
               "ACCEPTED",
               "REJECTED",
+              "CANCELED",
               null
             ]
           },


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary**
Added "CANCELED" value to the "enum" property in "bridge-api.json".

**Key Points**
1. Introduced new value to enum property.
2. File: bridge-api.json. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>