### PR TITLE
type should not be an array

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -2946,28 +2946,20 @@
               "type": "string"
             },
             "total": {
-              "type": [
-                "number",
-                "null"
-              ]
+              "type": "number",
+              "nullable": true
             },
             "accepted": {
-              "type": [
-                "number",
-                "null"
-              ]
+              "type": "number",
+              "nullable": true
             },
             "rejected": {
-              "type": [
-                "number",
-                "null"
-              ]
+              "type": "number",
+              "nullable": true
             },
             "null_count": {
-              "type": [
-                "number",
-                "null"
-              ]
+              "type": "number",
+              "nullable": true
             }
           }
         }


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary**

This pull request updates the "bridge-api.json" file, making the "total", "accepted", "rejected", and "null\_count" fields under "metrics" explicitly nullable numbers.

**Key Points**

1. Data types of several fields are changed to be explicitly nullable numbers.
2. Results in a clearer and more concise JSON schema definition. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>