### PR TITLE
fix: type should not be an array

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -2553,28 +2553,20 @@
               "type": "string"
             },
             "total": {
-              "type": [
-                "number",
-                "null"
-              ]
+              "type": "number",
+              "nullable": true
             },
             "accepted": {
-              "type": [
-                "number",
-                "null"
-              ]
+              "type": "number",
+              "nullable": true
             },
             "rejected": {
-              "type": [
-                "number",
-                "null"
-              ]
+              "type": "number",
+              "nullable": true
             },
             "null_count": {
-              "type": [
-                "number",
-                "null"
-              ]
+              "type": "number",
+              "nullable": true
             }
           }
         }


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary:**
This pull request modifies the "bridge-api.json" file to change nullable number fields to nullable number types.

**Key Points:**

1. "total", "accepted", "rejected", and "null\_count" fields under "metrics" changed from array of "number" and "null" to "number" with "nullable" property set to true. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>