### PR TITLE
fix: type should not be an array

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -2553,28 +2553,20 @@
               "type": "string"
             },
             "total": {
-              "type": [
-                "number",
-                "null"
-              ]
+              "type": "number",
+              "nullable": true
             },
             "accepted": {
-              "type": [
-                "number",
-                "null"
-              ]
+              "type": "number",
+              "nullable": true
             },
             "rejected": {
-              "type": [
-                "number",
-                "null"
-              ]
+              "type": "number",
+              "nullable": true
             },
             "null_count": {
-              "type": [
-                "number",
-                "null"
-              ]
+              "type": "number",
+              "nullable": true
             }
           }
         }


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary**

This pull request updates the "bridge-api.json" file, explicitly declaring nullability for certain fields.

**Key Points**

1. "total", "accepted", "rejected", and "null\_count" fields' data types are changed.
2. These fields are now nullable numbers, enhancing schema clarity and consistency. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>