### PR TITLE
fix: add `match_all` for name

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -3191,6 +3191,10 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
+          "match_all": {
+            "description": "The match_all field defines the validation logic for the specified fields within an object. If it is true, all specified fields in the object must match the corresponding fields in bVASP's database for the validation to succeed. If it is false, at least one of the specified fields in the object must match the corresponding fields in bVASP's database for the validation to succeed. Default is false.",
+            "type": "boolean"
+          },
           "name_identifier": {
             "$ref": "#/components/schemas/legalPersonNameIdentifierRule"
           },
@@ -3224,6 +3228,10 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
+          "match_all": {
+            "description": "The match_all field defines the validation logic for the specified fields within an object. If it is true, all specified fields in the object must match the corresponding fields in bVASP's database for the validation to succeed. If it is false, at least one of the specified fields in the object must match the corresponding fields in bVASP's database for the validation to succeed. Default is false.",
+            "type": "boolean"
+          },
           "name_identifier": {
             "$ref": "#/components/schemas/naturalPersonNameIdentifierRule"
           },


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview**
This PR adds a `match_all` field to the `legalPerson` and `naturalPerson` schemas in the `bridge-api.json` file. This field allows for more granular control over name matching logic during validation.

**Key Changes**
- Added a `match_all` boolean field to both the `legalPerson` and `naturalPerson` schemas.  This field dictates whether all specified name identifiers must match (true) or if at least one must match (false).
- Provided a clear description of the `match_all` field's purpose and behavior within the schema.

**Recommendations**
Stable for release. This is a straightforward schema addition with a clear purpose and good documentation.  The change enhances the flexibility of the API validation rules.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>