### PR TITLE
feat: natural_person and legal_person rule are required

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -2205,6 +2205,8 @@
           }
         },
         "required": [
+          "legal_person",
+          "natural_person",
           "signature"
         ]
       },


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview:**
This PR modifies the `bridge-api.json` file to make the `legal_person` and `natural_person` fields required.

**Key Changes:**
- Added `legal_person` and `natural_person` to the `required` array in the schema definition.

**Recommendations:**
Not deployment ready.  Clarify the impact of this change on existing API consumers and provide a migration plan if necessary.  Consider adding documentation about the new required fields.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>