### PR TITLE
feat: include `alliance` in GET vasp and vasp detail response

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -1979,6 +1979,11 @@
                 "type": "number"
               }
             }
+          },
+          "alliance": {
+            "title": "alliance",
+            "description": "This parameter specifies which Travel Rule protocol the VASP actually belongs to. Please note that the VASPs on the list are all interoperable with Sygna_Bridge, you could transfer the Travel Rule request to these VASPs via \"Sygna_Bridge\" protocol.",
+            "type": "string"
           }
         },
         "required": [
@@ -2072,6 +2077,11 @@
                 "$ref": "#/components/schemas/naturalPersonRule"
               }
             }
+          },
+          "alliance": {
+            "title": "alliance",
+            "description": "This parameter specifies which Travel Rule protocol the VASP actually belongs to. Please note that the VASPs on the list are all interoperable with Sygna_Bridge, you could transfer the Travel Rule request to these VASPs via \"Sygna_Bridge\" protocol.",
+            "type": "string"
           }
         },
         "required": [


### PR DESCRIPTION
 
 
 **PR Summary by Typo**
------------

**Overview**
This PR enhances the VASP and VASP detail API responses by introducing a new `alliance` field. This field provides information about the Travel Rule protocol associated with each VASP.

**Key Changes**
- Added an `alliance` string field to the `Vasp` and `VaspDetail` schemas within `bridge-api.json`.
- The `alliance` field includes a description specifying the Travel Rule protocol to which the VASP belongs.

**Recommendations**
deployment ready. This is a straightforward, additive schema change with no apparent negative impact on existing functionality.

### 🗂️ Work Breakdown

| Category  | Lines Changed |
|-----------|---------------|
| New Work  | 10 (100.0%)   |
| Total Changes | 10            | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>