### PR TITLE
feat: SYGN-16985 add alliance_id

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -1984,6 +1984,9 @@
             "title": "alliance",
             "description": "This parameter specifies which Travel Rule protocol the VASP actually belongs to. Please note that the VASPs on the list are all interoperable with Sygna_Bridge, you could transfer the Travel Rule request to these VASPs via \"Sygna_Bridge\" protocol.",
             "type": "string"
+          },
+          "alliance_id": {
+            "type": "string"
           }
         },
         "required": [
@@ -2081,6 +2084,9 @@
           "alliance": {
             "title": "alliance",
             "description": "This parameter specifies which Travel Rule protocol the VASP actually belongs to. Please note that the VASPs on the list are all interoperable with Sygna_Bridge, you could transfer the Travel Rule request to these VASPs via \"Sygna_Bridge\" protocol.",
+            "type": "string"
+          },
+          "alliance_id": {
             "type": "string"
           }
         },


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview**
This PR introduces a new `alliance_id` field to the API schema, enhancing the information available for VASP (Virtual Asset Service Provider) travel rule protocols. This change is associated with the `SYGN-16985` feature.

**Key Changes**
- Added an `alliance_id` field of type `string` to two locations within the `bridge-api.json` schema.

**Recommendations**
deployment ready. This is a straightforward schema addition that maintains backward compatibility as the new field is not marked as required.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 6 (100.0%)    |
| Total Changes | 6           | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>