### PR TITLE
feat: SYGN-17586 support self transfer checking rule

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -2074,10 +2074,38 @@
             "type": "object",
             "properties": {
               "legal_person": {
+                "description": "TBC",
                 "$ref": "#/components/schemas/legalPersonRule"
               },
               "natural_person": {
+                "description": "TBC",
                 "$ref": "#/components/schemas/naturalPersonRule"
+              },
+              "self": {
+                "type": "object",
+                "description": "TBC",
+                "additionalProperties": false,
+                "properties": {
+                  "legal_person": {
+                    "$ref": "#/components/schemas/legalPersonRule"
+                  },
+                  "natural_person": {
+                    "$ref": "#/components/schemas/naturalPersonRule"
+                  }
+                }
+              },
+              "third_party": {
+                "type": "object",
+                "description": "TBC",
+                "additionalProperties": false,
+                "properties": {
+                  "legal_person": {
+                    "$ref": "#/components/schemas/legalPersonRule"
+                  },
+                  "natural_person": {
+                    "$ref": "#/components/schemas/naturalPersonRule"
+                  }
+                }
               }
             }
           },
@@ -2211,10 +2239,38 @@
         "additionalProperties": false,
         "properties": {
           "legal_person": {
+            "description": "TBC",
             "$ref": "#/components/schemas/legalPersonRule"
           },
           "natural_person": {
+            "description": "TBC",
             "$ref": "#/components/schemas/naturalPersonRule"
+          },
+          "self": {
+            "type": "object",
+            "description": "TBC",
+            "additionalProperties": false,
+            "properties": {
+              "legal_person": {
+                "$ref": "#/components/schemas/legalPersonRule"
+              },
+              "natural_person": {
+                "$ref": "#/components/schemas/naturalPersonRule"
+              }
+            }
+          },
+          "third_party": {
+            "type": "object",
+            "description": "TBC",
+            "additionalProperties": false,
+            "properties": {
+              "legal_person": {
+                "$ref": "#/components/schemas/legalPersonRule"
+              },
+              "natural_person": {
+                "$ref": "#/components/schemas/naturalPersonRule"
+              }
+            }
           },
           "signature": {
             "$ref": "#/components/schemas/bridgeSignature"
@@ -2537,6 +2593,10 @@
         "properties": {
           "private_info": {
             "$ref": "#/components/schemas/bridgePrivateInfo"
+          },
+          "is_self_transfer": {
+            "type": "boolean",
+            "description": "TBC"
           },
           "transaction": {
             "$ref": "#/components/schemas/bridgeTransaction"


### PR DESCRIPTION
 **PR Summary by Typo**
------------

#### Overview
This PR introduces support for self-transfer checking rules by extending the API schema to differentiate between self and third-party transfers and adding a flag to identify self-transfers.

#### Key Changes
- Added new `self` and `third_party` objects, each containing `legal_person` and `natural_person` rule references, to relevant transfer rule schemas.
- Introduced a new boolean field `is_self_transfer` to the transfer object schema.
- Updated existing `legal_person` and `natural_person` rule definitions with placeholder descriptions.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 60 (100.0%)   |
| Total Changes | 60          | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>