### PR TITLE
feat: remove beneficiary-checking-rule required params

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -2277,8 +2277,6 @@
           }
         },
         "required": [
-          "legal_person",
-          "natural_person",
           "signature"
         ]
       },


### PR DESCRIPTION
 **PR Summary by Typo**
------------

#### Overview
This PR removes `legal_person` and `natural_person` from the list of required parameters for the `beneficiary-checking-rule` within the `bridge-api.json` schema.

#### Key Changes
- Modified `bridge-api.json` to no longer require `legal_person` and `natural_person` for the `beneficiary-checking-rule`.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| Churn    | 2 (100.0%)    |
| Total Changes | 2         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>