### PR TITLE
feat: update beneficiary-checking-rule schema

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -2093,19 +2093,6 @@
                     "$ref": "#/components/schemas/naturalPersonRule"
                   }
                 }
-              },
-              "third_party": {
-                "type": "object",
-                "description": "TBC",
-                "additionalProperties": false,
-                "properties": {
-                  "legal_person": {
-                    "$ref": "#/components/schemas/legalPersonRule"
-                  },
-                  "natural_person": {
-                    "$ref": "#/components/schemas/naturalPersonRule"
-                  }
-                }
               }
             }
           },
@@ -2247,19 +2234,6 @@
             "$ref": "#/components/schemas/naturalPersonRule"
           },
           "self": {
-            "type": "object",
-            "description": "TBC",
-            "additionalProperties": false,
-            "properties": {
-              "legal_person": {
-                "$ref": "#/components/schemas/legalPersonRule"
-              },
-              "natural_person": {
-                "$ref": "#/components/schemas/naturalPersonRule"
-              }
-            }
-          },
-          "third_party": {
             "type": "object",
             "description": "TBC",
             "additionalProperties": false,

--- a/bridge-api.json
+++ b/bridge-api.json
@@ -2277,6 +2277,8 @@
           }
         },
         "required": [
+          "legal_person",
+          "natural_person",
           "signature"
         ]
       },


### PR DESCRIPTION
 **PR Summary by Typo**
------------

#### Overview
This PR updates the `beneficiary-checking-rule` schema by removing the nested `third_party` object and making `legal_person` and `natural_person` directly required fields within the rule. This change simplifies the schema structure for defining beneficiary checking rules.

#### Key Changes
- Removed the `third_party` object from the `beneficiary-checking-rule` schema.
- Added `legal_person` and `natural_person` to the `required` array of the `beneficiary-checking-rule` schema.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| Churn    | 24 (92.3%)    |
| Rework   | 2 (7.7%)      |
| Total Changes | 26         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>