### PR TITLE
feat: update beneficiary-checking-rule schema

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -2074,16 +2074,14 @@
             "type": "object",
             "properties": {
               "legal_person": {
-                "description": "TBC",
                 "$ref": "#/components/schemas/legalPersonRule"
               },
               "natural_person": {
-                "description": "TBC",
                 "$ref": "#/components/schemas/naturalPersonRule"
               },
-              "self": {
+              "self_transfer": {
                 "type": "object",
-                "description": "TBC",
+                "description": "It is used when the originator sends the data transfer to himself/herself/itself.",
                 "additionalProperties": false,
                 "properties": {
                   "legal_person": {
@@ -2226,16 +2224,14 @@
         "additionalProperties": false,
         "properties": {
           "legal_person": {
-            "description": "TBC",
             "$ref": "#/components/schemas/legalPersonRule"
           },
           "natural_person": {
-            "description": "TBC",
             "$ref": "#/components/schemas/naturalPersonRule"
           },
-          "self": {
+          "self_transfer": {
             "type": "object",
-            "description": "TBC",
+            "description": "It is used when the originator sends the data transfer to himself/herself/itself.",
             "additionalProperties": false,
             "properties": {
               "legal_person": {
@@ -2570,7 +2566,7 @@
           },
           "is_self_transfer": {
             "type": "boolean",
-            "description": "TBC"
+            "description": "This param is used to declare whether the permission request is going to be sent to another wallet address of the same person."
           },
           "transaction": {
             "$ref": "#/components/schemas/bridgeTransaction"


### PR DESCRIPTION
 **PR Summary by Typo**
------------

#### Overview
This PR updates the `beneficiary-checking-rule` schema in `bridge-api.json` to improve clarity and accuracy of property names and descriptions.

#### Key Changes
- Renamed the `self` property to `self_transfer` within the `beneficiary-checking-rule` object.
- Updated the descriptions for `self_transfer` and `is_self_transfer` to provide more specific explanations.
- Removed placeholder "TBC" descriptions for `legal_person` and `natural_person` properties.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| Churn    | 4 (44.4%)     |
| Rework   | 5 (55.6%)     |
| Total Changes | 9           | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>