### PR TITLE
feat: SYGN-17586 support self transfer checking rule

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -2078,6 +2078,19 @@
               },
               "natural_person": {
                 "$ref": "#/components/schemas/naturalPersonRule"
+              },
+              "self_transfer": {
+                "type": "object",
+                "description": "It is used when the originator sends the data transfer to himself/herself/itself.",
+                "additionalProperties": false,
+                "properties": {
+                  "legal_person": {
+                    "$ref": "#/components/schemas/legalPersonRule"
+                  },
+                  "natural_person": {
+                    "$ref": "#/components/schemas/naturalPersonRule"
+                  }
+                }
               }
             }
           },
@@ -2215,6 +2228,19 @@
           },
           "natural_person": {
             "$ref": "#/components/schemas/naturalPersonRule"
+          },
+          "self_transfer": {
+            "type": "object",
+            "description": "It is used when the originator sends the data transfer to himself/herself/itself.",
+            "additionalProperties": false,
+            "properties": {
+              "legal_person": {
+                "$ref": "#/components/schemas/legalPersonRule"
+              },
+              "natural_person": {
+                "$ref": "#/components/schemas/naturalPersonRule"
+              }
+            }
           },
           "signature": {
             "$ref": "#/components/schemas/bridgeSignature"
@@ -2537,6 +2563,10 @@
         "properties": {
           "private_info": {
             "$ref": "#/components/schemas/bridgePrivateInfo"
+          },
+          "is_self_transfer": {
+            "type": "boolean",
+            "description": "This param is used to declare whether the permission request is going to be sent to another wallet address of the same person."
           },
           "transaction": {
             "$ref": "#/components/schemas/bridgeTransaction"


### PR DESCRIPTION
 **PR Summary by Typo**
------------

#### Overview
This PR introduces support for self-transfer checking rules within the API schema, defining new structures to identify and manage transfers where the originator is also the recipient.

#### Key Changes
- Added a `self_transfer` object to the API schema, allowing for specific rules for transfers to oneself, including `legal_person` and `natural_person` rule references.
- Introduced an `is_self_transfer` boolean field to indicate if a permission request is for a self-transfer.
- Updated the `bridge-api.json` OpenAPI definition to reflect these new schema additions.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 30 (100.0%)   |
| Total Changes | 30          | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>