### PR TITLE
feat: SYGN-16967 support currency v3

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -2078,6 +2078,19 @@
               },
               "natural_person": {
                 "$ref": "#/components/schemas/naturalPersonRule"
+              },
+              "self_transfer": {
+                "type": "object",
+                "description": "It is used when the originator sends the data transfer to himself/herself/itself.",
+                "additionalProperties": false,
+                "properties": {
+                  "legal_person": {
+                    "$ref": "#/components/schemas/legalPersonRule"
+                  },
+                  "natural_person": {
+                    "$ref": "#/components/schemas/naturalPersonRule"
+                  }
+                }
               }
             }
           },
@@ -2215,6 +2228,19 @@
           },
           "natural_person": {
             "$ref": "#/components/schemas/naturalPersonRule"
+          },
+          "self_transfer": {
+            "type": "object",
+            "description": "It is used when the originator sends the data transfer to himself/herself/itself.",
+            "additionalProperties": false,
+            "properties": {
+              "legal_person": {
+                "$ref": "#/components/schemas/legalPersonRule"
+              },
+              "natural_person": {
+                "$ref": "#/components/schemas/naturalPersonRule"
+              }
+            }
           },
           "signature": {
             "$ref": "#/components/schemas/bridgeSignature"
@@ -2537,6 +2563,10 @@
         "properties": {
           "private_info": {
             "$ref": "#/components/schemas/bridgePrivateInfo"
+          },
+          "is_self_transfer": {
+            "type": "boolean",
+            "description": "This param is used to declare whether the permission request is going to be sent to another wallet address of the same person."
           },
           "transaction": {
             "$ref": "#/components/schemas/bridgeTransaction"

--- a/bridge-api.json
+++ b/bridge-api.json
@@ -383,6 +383,16 @@
               "type": "string",
               "example": "Bitcoin"
             }
+          },
+          {
+            "in": "query",
+            "name": "version",
+            "description": "crypto currency list version 3",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "v3"
+            }
           }
         ],
         "responses": {
@@ -2417,6 +2427,12 @@
             "type": "string",
             "minLength": 1
           },
+          "currency_id_v3": {
+            "type": "string"
+          },
+          "network": {
+            "type": "string"
+          },
           "amount": {
             "type": "string",
             "minLength": 1
@@ -2609,6 +2625,12 @@
           "currency_id": {
             "type": "string"
           },
+          "currency_id_v3": {
+            "type": "string"
+          },
+          "network": {
+            "type": "string"
+          },
           "addrs": {
             "type": "array",
             "items": {
@@ -2622,7 +2644,6 @@
         },
         "required": [
           "vasp_code",
-          "currency_id",
           "addrs",
           "signature"
         ],
@@ -2968,6 +2989,12 @@
           "currency_id": {
             "type": "string"
           },
+          "currency_id_v3": {
+            "type": "string"
+          },
+          "network": {
+            "type": "string"
+          },
           "addrs": {
             "type": "array",
             "items": {
@@ -2984,7 +3011,6 @@
           }
         },
         "required": [
-          "currency_id",
           "addrs"
         ]
       },


### PR DESCRIPTION
 **PR Summary by Typo**
------------

#### Overview
This PR introduces support for currency version 3 and enhances the Bridge API with self-transfer functionality, allowing for more granular control and identification of self-originated transactions.

#### Key Changes
- Added a `version` query parameter to the `GET /crypto/currencies` endpoint to filter for v3 currencies.
- Introduced a `self_transfer` object schema within `bridgePermissionRequest` and `bridgePermissionResponse` to define rules for self-originated transfers.
- Added `currency_id_v3` and `network` fields to the `bridgeTransaction`, `bridgeTransferRequest`, and `bridgeTransferResponse` schemas.
- Included an `is_self_transfer` boolean field in the `bridgePermissionRequest` schema.
- Modified `bridgeTransferRequest` and `bridgeTransferResponse` to make `currency_id` an optional field.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 58 (96.7%)    |
| Churn       | 2 (3.3%)      |
| Total Changes | 60          | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>