### PR TITLE
feat: SYGN-16967 support currency v3

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -2319,6 +2319,42 @@
         ],
         "additionalProperties": false
       },
+      "bridgeCurrencyV3Item": {
+        "title": "CurrencyV3Item",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "symbol": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "platforms": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "token_address": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "token_address"
+              ]
+            }
+          }
+        },
+        "required": [
+          "id",
+          "symbol",
+          "name",
+          "platforms"
+        ],
+        "additionalProperties": false
+      },
       "bridgeSupportedCoins": {
         "title": "supported_coins",
         "type": "object",
@@ -2326,7 +2362,14 @@
           "supported_coins": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/bridgeCurrencyItem"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/bridgeCurrencyItem"
+                },
+                {
+                  "$ref": "#/components/schemas/bridgeCurrencyV3Item"
+                }
+              ]
             }
           }
         },


### PR DESCRIPTION
 **PR Summary by Typo**
------------

#### Overview
This PR introduces support for a new currency version (v3) within the bridge API by defining a new schema and allowing it as an alternative type for supported coins.

#### Key Changes
- Added a new schema `bridgeCurrencyV3Item` to `bridge-api.json` to define the structure of currency v3 items, including `id`, `symbol`, `name`, and `platforms`.
- Modified the `bridgeSupportedCoins` schema to accept either `bridgeCurrencyItem` or `bridgeCurrencyV3Item` using `oneOf`, enabling backward compatibility while supporting the new version.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 43 (97.7%)    |
| Rework      | 1 (2.3%)      |
| Total Changes | 44            | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>