### PR TITLE
fix: hide kyt info from GET currencies response

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -2343,7 +2343,8 @@
               },
               "required": [
                 "token_address"
-              ]
+              ],
+              "additionalProperties": false
             }
           }
         },


### PR DESCRIPTION
 **PR Summary by Typo**
------------

#### Overview
This PR addresses a bug by hiding sensitive KYT (Know Your Transaction) information from the `GET currencies` API response. This is achieved by restricting the properties allowed in the response schema.

#### Key Changes
- Added `additionalProperties: false` to a schema definition in `bridge-api.json`.
- This change ensures that only explicitly defined properties are included in the API response, thereby preventing the exposure of KYT data.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 1 (50.0%)     |
| Rework      | 1 (50.0%)     |
| Total Changes | 2             | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>