### PR TITLE
feat: SYGN-16967 support v3 currency

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -383,6 +383,16 @@
               "type": "string",
               "example": "Bitcoin"
             }
+          },
+          {
+            "in": "query",
+            "name": "version",
+            "description": "crypto currency list version 3",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "v3"
+            }
           }
         ],
         "responses": {
@@ -2309,6 +2319,43 @@
         ],
         "additionalProperties": false
       },
+      "bridgeCurrencyV3Item": {
+        "title": "CurrencyV3Item",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "symbol": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "platforms": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "token_address": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "token_address"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "id",
+          "symbol",
+          "name",
+          "platforms"
+        ],
+        "additionalProperties": false
+      },
       "bridgeSupportedCoins": {
         "title": "supported_coins",
         "type": "object",
@@ -2316,7 +2363,14 @@
           "supported_coins": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/bridgeCurrencyItem"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/bridgeCurrencyItem"
+                },
+                {
+                  "$ref": "#/components/schemas/bridgeCurrencyV3Item"
+                }
+              ]
             }
           }
         },
@@ -2416,6 +2470,12 @@
           "currency_id": {
             "type": "string",
             "minLength": 1
+          },
+          "currency_id_v3": {
+            "type": "string"
+          },
+          "network": {
+            "type": "string"
           },
           "amount": {
             "type": "string",
@@ -2609,6 +2669,12 @@
           "currency_id": {
             "type": "string"
           },
+          "currency_id_v3": {
+            "type": "string"
+          },
+          "network": {
+            "type": "string"
+          },
           "addrs": {
             "type": "array",
             "items": {
@@ -2622,7 +2688,6 @@
         },
         "required": [
           "vasp_code",
-          "currency_id",
           "addrs",
           "signature"
         ],
@@ -2968,6 +3033,12 @@
           "currency_id": {
             "type": "string"
           },
+          "currency_id_v3": {
+            "type": "string"
+          },
+          "network": {
+            "type": "string"
+          },
           "addrs": {
             "type": "array",
             "items": {
@@ -2984,7 +3055,6 @@
           }
         },
         "required": [
-          "currency_id",
           "addrs"
         ]
       },


### PR DESCRIPTION
 **PR Summary by Typo**
------------

#### Overview
This PR introduces support for a new version (v3) of currency data within the API, allowing for more detailed currency information, particularly concerning platform-specific token details. It enhances the API's flexibility by enabling requests for different currency data versions and expanding the data model.

#### Key Changes
- Added a `version` query parameter to an API endpoint to specifically request v3 crypto currency lists.
- Introduced a new `bridgeCurrencyV3Item` schema to define the structure for v3 currencies, including `id`, `symbol`, `name`, and `platforms` with `token_address`.
- Modified the `bridgeSupportedCoins` schema to accept either the existing `bridgeCurrencyItem` or the new `bridgeCurrencyV3Item`.
- Added `currency_id_v3` and `network` fields to several request/response schemas related to transactions and deposit addresses.
- Made the `currency_id` field optional in `bridgeSupportedDepositAddressesRequest` and `bridgeSupportedDepositAddressesResponse` schemas.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 72 (96.0%)    |
| Churn       | 2 (2.7%)      |
| Rework      | 1 (1.3%)      |
| Total Changes | 75            | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>