### PR TITLE
release: 1.42.0

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -2078,6 +2078,19 @@
               },
               "natural_person": {
                 "$ref": "#/components/schemas/naturalPersonRule"
+              },
+              "self_transfer": {
+                "type": "object",
+                "description": "It is used when the originator sends the data transfer to himself/herself/itself.",
+                "additionalProperties": false,
+                "properties": {
+                  "legal_person": {
+                    "$ref": "#/components/schemas/legalPersonRule"
+                  },
+                  "natural_person": {
+                    "$ref": "#/components/schemas/naturalPersonRule"
+                  }
+                }
               }
             }
           },
@@ -2215,6 +2228,19 @@
           },
           "natural_person": {
             "$ref": "#/components/schemas/naturalPersonRule"
+          },
+          "self_transfer": {
+            "type": "object",
+            "description": "It is used when the originator sends the data transfer to himself/herself/itself.",
+            "additionalProperties": false,
+            "properties": {
+              "legal_person": {
+                "$ref": "#/components/schemas/legalPersonRule"
+              },
+              "natural_person": {
+                "$ref": "#/components/schemas/naturalPersonRule"
+              }
+            }
           },
           "signature": {
             "$ref": "#/components/schemas/bridgeSignature"
@@ -2537,6 +2563,10 @@
         "properties": {
           "private_info": {
             "$ref": "#/components/schemas/bridgePrivateInfo"
+          },
+          "is_self_transfer": {
+            "type": "boolean",
+            "description": "This param is used to declare whether the permission request is going to be sent to another wallet address of the same person."
           },
           "transaction": {
             "$ref": "#/components/schemas/bridgeTransaction"


### PR DESCRIPTION
 **PR Summary by Typo**
------------

#### Overview
This PR introduces new schema definitions related to self-transfers within the API, expanding the data model to explicitly handle cases where an originator transfers funds to themselves.

#### Key Changes
- Added a new `self_transfer` object schema to define rules for both `legal_person` and `natural_person` in self-transfer scenarios.
- Introduced an `is_self_transfer` boolean field to indicate whether a permission request is for a self-transfer to another wallet address of the same person.
- These changes are reflected in the `bridge-api.json` OpenAPI specification.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 30 (100.0%)   |
| Total Changes | 30          | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>