### PR TITLE
feat: SYGN-18023 vasp_code is not necessary

### DIFF
--- a/bridge-api.json
+++ b/bridge-api.json
@@ -2224,7 +2224,6 @@
           }
         },
         "required": [
-          "vasp_code",
           "signature"
         ]
       },


### PR DESCRIPTION
 **PR Summary by Typo**
------------

#### Overview
This PR removes `vasp_code` from the list of required fields in the `bridge-api.json` schema, indicating it is no longer a necessary parameter for certain API operations.

#### Key Changes
- Removed `"vasp_code"` from the `required` array within the `bridge-api.json` schema.

#### Work Breakdown
| Category | Lines Changed |
|---|---|
| Churn | 1 (100.0%) |
| Total Changes | 1 | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>